### PR TITLE
Update _app.go

### DIFF
--- a/app/templates/app/_app.go
+++ b/app/templates/app/_app.go
@@ -25,11 +25,11 @@ func LoadConfig() *Config {
 	}
 	cfg := Config{}
 
+	err := env.Parse(&cfg)
+	
 	if _, err := toml.DecodeFile("configs/"+initialEnv+".toml", &cfg); err != nil {
 		log.Fatalf("Could not load %s config with error: %s", err.Error())
 	}
-
-	err := env.Parse(&cfg)
 
 	if err != nil {
 		log.Fatalf("Failed to load env variables. %+v\n", err)


### PR DESCRIPTION
Calling `env.Parse` before decoding the config files stops the envDefault values from overriding newer values set inside the config files.